### PR TITLE
Add interactive segmentation UI for chemokine diagrams

### DIFF
--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,0 +1,1 @@
+# Minimal docs app for tests

--- a/docs/apps.py
+++ b/docs/apps.py
@@ -1,0 +1,4 @@
+from django.apps import AppConfig
+
+class DocsConfig(AppConfig):
+    name = 'docs'

--- a/home/forms.py
+++ b/home/forms.py
@@ -4,3 +4,12 @@ from django.core.validators import EmailValidator
 class DateForm(forms.Form):
     start = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
     end = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
+
+
+class ChemokineDiagramForm(forms.Form):
+    """Form allowing users to paste a sequence that will be segmented interactively."""
+
+    sequence = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 5, "placeholder": "Enter protein sequence"}),
+        label="Sequence",
+    )

--- a/home/templates/home/chemokine_diagram.html
+++ b/home/templates/home/chemokine_diagram.html
@@ -1,0 +1,29 @@
+{% extends "home/base.html" %}
+{% load static %}
+{% block content %}
+<div class="container mt-4">
+  <h2>Custom Chemokine Diagram</h2>
+  {% if svg %}
+    <div class="mt-4">{{ svg|safe }}</div>
+    <a href="{% url 'chemokine_diagram' %}" class="btn btn-secondary mt-3">Start Over</a>
+  {% elif seq %}
+    <form id="segment-form" method="post">
+      {% csrf_token %}
+      <input type="hidden" name="sequence" value="{{ seq }}">
+      <input type="hidden" name="segments" id="id_segments">
+      <div id="segmenter" data-seq="{{ seq }}" class="mb-3"></div>
+      <button type="submit" class="btn btn-success">Generate Diagram</button>
+    </form>
+    <script src="{% static 'home/js/segmenter.js' %}"></script>
+  {% else %}
+    <form method="post">
+      {% csrf_token %}
+      <div class="mb-3">
+        {{ form.sequence.label_tag }}
+        {{ form.sequence }}
+      </div>
+      <button type="submit" class="btn btn-primary">Submit Sequence</button>
+    </form>
+  {% endif %}
+</div>
+{% endblock %}

--- a/home/urls.py
+++ b/home/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('about/', views.about, name='about'),
     path('example/', views.example, name='example'),
     path('charts/', views.charts, name='charts'),
+    path('chemokine-diagram/', views.chemokine_diagram, name='chemokine_diagram'),
 ]

--- a/home/views.py
+++ b/home/views.py
@@ -1,10 +1,13 @@
 from django.shortcuts import render
 from collections import defaultdict
 import plotly.graph_objects as go
-from .forms import DateForm
+from django.utils.html import escape
+
+from .forms import DateForm, ChemokineDiagramForm
 from protein.models import Protein
 from structure.models import Structure, Rotamer
 from common.models import ResiduePosition
+from common.diagrams_chemokine import DrawArrestinPlot
 from collections import Counter
 
 def index(request):
@@ -44,6 +47,43 @@ def charts(request):
         'structure_state_pie': structure_state_pie,
         'ccn_position_barplot': ccn_position_barplot,
     })
+
+
+def chemokine_diagram(request):
+    """Allow users to submit a sequence and then interactively define segments."""
+
+    if request.method == "POST":
+        seq = request.POST.get("sequence", "").replace("\n", "").strip().upper()
+        segment_def = request.POST.get("segments", "").strip()
+
+        if segment_def:
+            class ResidueObj:
+                def __init__(self, seq_num, aa, seg):
+                    self.sequence_number = seq_num
+                    self.amino_acid = aa
+                    self.segment = seg
+                    self.ccn_number = None
+
+            residues = []
+            try:
+                for item in segment_def.split(","):
+                    if not item.strip():
+                        continue
+                    range_part, seg_name = item.split(":")
+                    start, end = [int(x) for x in range_part.split("-")]
+                    seg_name = seg_name.strip()
+                    for i in range(start, end + 1):
+                        aa = seq[i - 1] if 0 <= i - 1 < len(seq) else "X"
+                        residues.append(ResidueObj(i, aa, seg_name))
+                svg = str(DrawArrestinPlot(residues, "Custom Sequence", nobuttons=True))
+            except Exception as exc:
+                svg = f"<p>Error generating diagram: {escape(exc)}</p>"
+            return render(request, "home/chemokine_diagram.html", {"svg": svg})
+        else:
+            return render(request, "home/chemokine_diagram.html", {"seq": seq})
+
+    form = ChemokineDiagramForm()
+    return render(request, "home/chemokine_diagram.html", {"form": form})
 
 
 

--- a/static/home/js/segmenter.js
+++ b/static/home/js/segmenter.js
@@ -1,0 +1,94 @@
+const SEGMENT_NAMES = [
+  "N-term",
+  "CX",
+  "N-loop",
+  "B1",
+  "30s-loop",
+  "B2",
+  "40s-loop",
+  "B3",
+  "50s-loop",
+  "Helix",
+  "C-term"
+];
+
+document.addEventListener("DOMContentLoaded", () => {
+  const segmenter = document.getElementById("segmenter");
+  if (!segmenter) return;
+  const sequence = segmenter.dataset.seq;
+  const chars = sequence.split("");
+
+  const container = document.createElement("div");
+  container.id = "sequence-container";
+  container.style.position = "relative";
+  container.style.fontFamily = "monospace";
+  container.style.whiteSpace = "pre";
+  container.style.userSelect = "none";
+  segmenter.appendChild(container);
+
+  chars.forEach(ch => {
+    const span = document.createElement("span");
+    span.textContent = ch;
+    container.appendChild(span);
+  });
+
+  const charWidth = container.firstChild.getBoundingClientRect().width;
+  container.style.width = charWidth * chars.length + "px";
+
+  const separators = [];
+  const totalSeparators = SEGMENT_NAMES.length - 1;
+  for (let i = 1; i <= totalSeparators; i++) {
+    const sep = document.createElement("div");
+    sep.className = "separator";
+    sep.style.position = "absolute";
+    sep.style.top = 0;
+    sep.style.bottom = 0;
+    sep.style.width = "2px";
+    sep.style.background = "red";
+    sep.style.cursor = "ew-resize";
+    const pos = Math.round((i * chars.length) / SEGMENT_NAMES.length);
+    sep.style.left = pos * charWidth + "px";
+    sep.dataset.index = i - 1;
+    container.appendChild(sep);
+    separators.push(sep);
+  }
+
+  let active = null;
+  container.addEventListener("mousedown", e => {
+    if (e.target.classList.contains("separator")) {
+      active = e.target;
+      e.preventDefault();
+    }
+  });
+  document.addEventListener("mousemove", e => {
+    if (!active) return;
+    const rect = container.getBoundingClientRect();
+    let x = e.clientX - rect.left;
+    const index = parseInt(active.dataset.index);
+    const min = index === 0 ? 0 : parseFloat(separators[index - 1].style.left) + charWidth;
+    const max = index === separators.length - 1 ? rect.width : parseFloat(separators[index + 1].style.left) - charWidth;
+    if (x < min) x = min;
+    if (x > max) x = max;
+    active.style.left = x + "px";
+  });
+  document.addEventListener("mouseup", () => {
+    active = null;
+  });
+
+  const form = document.getElementById("segment-form");
+  form.addEventListener("submit", () => {
+    const segmentsInput = document.getElementById("id_segments");
+    const positions = separators
+      .map(sep => parseFloat(sep.style.left) / charWidth)
+      .map(pos => Math.round(pos));
+    let prev = 1;
+    const ranges = [];
+    positions.forEach((p, idx) => {
+      const end = p;
+      ranges.push(`${prev}-${end}:${SEGMENT_NAMES[idx]}`);
+      prev = end + 1;
+    });
+    ranges.push(`${prev}-${chars.length}:${SEGMENT_NAMES[SEGMENT_NAMES.length - 1]}`);
+    segmentsInput.value = ranges.join(",");
+  });
+});


### PR DESCRIPTION
## Summary
- allow users to submit a sequence and interactively drag segment boundaries before rendering chemokine diagrams
- provide a new segmenter JavaScript utility to map dragged positions to segment ranges
- update custom diagram page template and view for the two-step workflow

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a70ef41fdc8323b0dd78508c9bfcd7