### PR TITLE
Optimize chart page queries

### DIFF
--- a/home/templates/home/charts.html
+++ b/home/templates/home/charts.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 <div class="container py-4">
 
     <div class="p-3 mb-2 bg-light rounded-3">

--- a/home/views.py
+++ b/home/views.py
@@ -30,23 +30,30 @@ def example(request):
 
 
 def charts(request):
-    structure_chart = generate_structure_chart()
-    species_pie_chart = generate_species_pie_chart()
-    type_pie_chart = generate_structure_type_pie_chart()
-    chemokine_type_pie = generate_chemokine_type_pie_chart()
-    subfamily_pie = generate_chemokine_subfamily_pie_chart()
-    structure_state_pie = generate_structure_state_pie_chart()
+    structures = list(
+        Structure.objects.select_related("protein", "structure_type").all()
+    )
+    structure_chart = generate_structure_chart(structures)
+    species_pie_chart = generate_species_pie_chart(structures)
+    type_pie_chart = generate_structure_type_pie_chart(structures)
+    chemokine_type_pie = generate_chemokine_type_pie_chart(structures)
+    subfamily_pie = generate_chemokine_subfamily_pie_chart(structures)
+    structure_state_pie = generate_structure_state_pie_chart(structures)
     ccn_position_barplot = generate_ccn_position_barplot()
 
-    return render(request, 'home/charts.html', {
-        'structure_chart': structure_chart,
-        'species_pie_chart': species_pie_chart,
-        'type_pie_chart': type_pie_chart,
-        'chemokine_type_pie': chemokine_type_pie,
-        'subfamily_pie': subfamily_pie,
-        'structure_state_pie': structure_state_pie,
-        'ccn_position_barplot': ccn_position_barplot,
-    })
+    return render(
+        request,
+        "home/charts.html",
+        {
+            "structure_chart": structure_chart,
+            "species_pie_chart": species_pie_chart,
+            "type_pie_chart": type_pie_chart,
+            "chemokine_type_pie": chemokine_type_pie,
+            "subfamily_pie": subfamily_pie,
+            "structure_state_pie": structure_state_pie,
+            "ccn_position_barplot": ccn_position_barplot,
+        },
+    )
 
 
 def chemokine_diagram(request):
@@ -87,32 +94,47 @@ def chemokine_diagram(request):
 
 
 
-def generate_structure_chart():
+def generate_structure_chart(structures=None):
     """Helper function to generate chart data for structures published per year and cumulative total."""
-    structures = Structure.objects.all()
+    if structures is None:
+        structures = Structure.objects.all()
     year_counts = count_publications_by_year(structures)
     
     sorted_years = sorted(year_counts.keys())
     publication_counts = [year_counts[year] for year in sorted_years]
     cumulative_counts = [sum(publication_counts[:i + 1]) for i in range(len(publication_counts))]
 
-    fig = go.Figure(data=[
-        go.Bar(x=sorted_years, y=publication_counts, name='Structures Published', marker_color='blue'),
-        go.Scatter(x=sorted_years, y=cumulative_counts, mode='lines+markers', name='Cumulative Structures',
-                   line=dict(color='red', width=2), marker=dict(color='red', size=6))
-    ])
-
-    fig.update_layout(
-        #title={'text': "Number of Chemokine Structures Published per Year and Cumulative Total", 'font_size': 24, 'xanchor': 'center', 'x': 0.5},
-        xaxis_title='Year', yaxis_title='Number of Structures',
-        legend=dict(x=0.01, y=0.99, bordercolor='Black', borderwidth=1)
+    fig = go.Figure(
+        data=[
+            go.Bar(
+                x=sorted_years,
+                y=publication_counts,
+                name="Structures Published",
+                marker_color="blue",
+            ),
+            go.Scatter(
+                x=sorted_years,
+                y=cumulative_counts,
+                mode="lines+markers",
+                name="Cumulative Structures",
+                line=dict(color="red", width=2),
+                marker=dict(color="red", size=6),
+            ),
+        ]
     )
 
-    return fig.to_html()
+    fig.update_layout(
+        xaxis_title="Year",
+        yaxis_title="Number of Structures",
+        legend=dict(x=0.01, y=0.99, bordercolor="Black", borderwidth=1),
+    )
 
-def generate_species_pie_chart():
+    return fig.to_html(full_html=False, include_plotlyjs=False, div_id="structure_chart")
+
+def generate_species_pie_chart(structures=None):
     """Generates a pie chart showing the species distribution of proteins that have structures."""
-    structures = Structure.objects.select_related('protein').all()
+    if structures is None:
+        structures = Structure.objects.select_related('protein').all()
 
     species_counts = defaultdict(int)
     for structure in structures:
@@ -122,10 +144,28 @@ def generate_species_pie_chart():
     labels = list(species_counts.keys())
     values = list(species_counts.values())
 
-    fig = go.Figure(data=[go.Pie(labels=labels, values=values, hole=0.3, textinfo='none', showlegend=False)])
-    fig.update_layout(title=None)
+    fig = go.Figure(
+        data=[
+            go.Pie(
+                labels=labels,
+                values=values,
+                hole=0.3,
+                textinfo="label+percent",
+                textposition="inside",
+            )
+        ]
+    )
+    fig.update_layout(title=None, showlegend=True)
 
-    return fig.to_html()
+    html = fig.to_html(full_html=False, include_plotlyjs=False, div_id="species_pie")
+    html += (
+        "<script>"  # add click handler to filter browse page
+        "document.getElementById('species_pie').on('plotly_click', function(data){"
+        "var label=data.points[0].label;"
+        "window.location='/protein?species=' + encodeURIComponent(label);"
+        "});" "</script>"
+    )
+    return html
 
 
 def count_publications_by_year(structures):
@@ -136,9 +176,10 @@ def count_publications_by_year(structures):
             year_counts[structure.publication_date.year] += 1
     return year_counts
 
-def generate_structure_type_pie_chart():
+def generate_structure_type_pie_chart(structures=None):
     """Generates a pie chart showing the distribution of structure types (X-ray, NMR, Cryo-EM)."""
-    structures = Structure.objects.select_related('structure_type').all()
+    if structures is None:
+        structures = Structure.objects.select_related('structure_type').all()
 
     type_counts = defaultdict(int)
     for structure in structures:
@@ -148,16 +189,33 @@ def generate_structure_type_pie_chart():
     labels = list(type_counts.keys())
     values = list(type_counts.values())
 
-    fig = go.Figure(data=[go.Pie(labels=labels, values=values, hole=0.3, textinfo='none', showlegend=False)])
-    fig.update_layout(
-        title=None
+    fig = go.Figure(
+        data=[
+            go.Pie(
+                labels=labels,
+                values=values,
+                hole=0.3,
+                textinfo="label+percent",
+                textposition="inside",
+            )
+        ]
     )
+    fig.update_layout(title=None, showlegend=True)
 
-    return fig.to_html()
+    html = fig.to_html(full_html=False, include_plotlyjs=False, div_id="structure_type_pie")
+    html += (
+        "<script>"
+        "document.getElementById('structure_type_pie').on('plotly_click', function(data){"
+        "var label=data.points[0].label;"
+        "window.location='/structure?method=' + encodeURIComponent(label);"
+        "});" "</script>"
+    )
+    return html
 
-def generate_chemokine_type_pie_chart():
+def generate_chemokine_type_pie_chart(structures=None):
     """Generates a pie chart showing distribution of chemokine types for proteins with structures."""
-    structures = Structure.objects.select_related('protein').all()
+    if structures is None:
+        structures = Structure.objects.select_related('protein').all()
 
     type_counts = defaultdict(int)
     for structure in structures:
@@ -167,15 +225,34 @@ def generate_chemokine_type_pie_chart():
     labels = list(type_counts.keys())
     values = list(type_counts.values())
 
-    fig = go.Figure(data=[go.Pie(labels=labels, values=values, hole=0.3, textinfo='none', showlegend=False)])
-    fig.update_layout(title=None)
+    fig = go.Figure(
+        data=[
+            go.Pie(
+                labels=labels,
+                values=values,
+                hole=0.3,
+                textinfo="label+percent",
+                textposition="inside",
+            )
+        ]
+    )
+    fig.update_layout(title=None, showlegend=True)
 
-    return fig.to_html()
+    html = fig.to_html(full_html=False, include_plotlyjs=False, div_id="chemokine_type_pie")
+    html += (
+        "<script>"
+        "document.getElementById('chemokine_type_pie').on('plotly_click', function(data){"
+        "var label=data.points[0].label;"
+        "window.location='/protein?type=' + encodeURIComponent(label);"
+        "});" "</script>"
+    )
+    return html
 
 
-def generate_chemokine_subfamily_pie_chart():
+def generate_chemokine_subfamily_pie_chart(structures=None):
     """Generates a pie chart showing distribution of chemokine subfamilies for proteins with structures."""
-    structures = Structure.objects.select_related('protein').all()
+    if structures is None:
+        structures = Structure.objects.select_related('protein').all()
 
     subfamily_counts = defaultdict(int)
     for structure in structures:
@@ -185,14 +262,33 @@ def generate_chemokine_subfamily_pie_chart():
     labels = list(subfamily_counts.keys())
     values = list(subfamily_counts.values())
 
-    fig = go.Figure(data=[go.Pie(labels=labels, values=values, hole=0.3, textinfo='none', showlegend=False)])
-    fig.update_layout(title=None)
+    fig = go.Figure(
+        data=[
+            go.Pie(
+                labels=labels,
+                values=values,
+                hole=0.3,
+                textinfo="label+percent",
+                textposition="inside",
+            )
+        ]
+    )
+    fig.update_layout(title=None, showlegend=True)
 
-    return fig.to_html()
+    html = fig.to_html(full_html=False, include_plotlyjs=False, div_id="subfamily_pie")
+    html += (
+        "<script>"
+        "document.getElementById('subfamily_pie').on('plotly_click', function(data){"
+        "var label=data.points[0].label;"
+        "window.location='/protein?subfamily=' + encodeURIComponent(label);"
+        "});" "</script>"
+    )
+    return html
 
-def generate_structure_state_pie_chart():
+def generate_structure_state_pie_chart(structures=None):
     """Generates a pie chart showing the distribution of structure states."""
-    structures = Structure.objects.all()
+    if structures is None:
+        structures = Structure.objects.all()
 
     state_counts = defaultdict(int)
     for structure in structures:
@@ -202,10 +298,28 @@ def generate_structure_state_pie_chart():
     labels = list(state_counts.keys())
     values = list(state_counts.values())
 
-    fig = go.Figure(data=[go.Pie(labels=labels, values=values, hole=0.3, textinfo='none', showlegend=False)])
-    fig.update_layout(title=None)
+    fig = go.Figure(
+        data=[
+            go.Pie(
+                labels=labels,
+                values=values,
+                hole=0.3,
+                textinfo="label+percent",
+                textposition="inside",
+            )
+        ]
+    )
+    fig.update_layout(title=None, showlegend=True)
 
-    return fig.to_html()
+    html = fig.to_html(full_html=False, include_plotlyjs=False, div_id="structure_state_pie")
+    html += (
+        "<script>"
+        "document.getElementById('structure_state_pie').on('plotly_click', function(data){"
+        "var label=data.points[0].label;"
+        "window.location='/structure?state=' + encodeURIComponent(label);"
+        "});" "</script>"
+    )
+    return html
 
 def generate_ccn_position_barplot():
     """Generates a barplot showing how much each CCN position occurs across all chemokine chains (rotamers), ordered by canonical position."""
@@ -233,5 +347,5 @@ def generate_ccn_position_barplot():
         margin=dict(l=40, r=20, t=60, b=90),
         xaxis_tickangle=45,
     )
-    return fig.to_html()
+    return fig.to_html(full_html=False, include_plotlyjs=False, div_id="ccn_position_barplot")
 

--- a/protein/templates/protein_browser.html
+++ b/protein/templates/protein_browser.html
@@ -151,6 +151,23 @@
             }
         });
 
+        var params = new URLSearchParams(window.location.search);
+        var type = params.get('type');
+        var subfamily = params.get('subfamily');
+        var species = params.get('species');
+        if (type) {
+            table.column(0).search('^' + type + '$', true, false).draw();
+            $(table.column(0).header()).find('select').val(type);
+        }
+        if (subfamily) {
+            table.column(1).search('^' + subfamily + '$', true, false).draw();
+            $(table.column(1).header()).find('select').val(subfamily);
+        }
+        if (species) {
+            table.column(2).search('^' + species + '$', true, false).draw();
+            $(table.column(2).header()).find('select').val(species);
+        }
+
         // Clickable row functionality
         $('#partners tbody').on('click', 'tr', function(event) {
             // Ignore click if target is a link or a child of a link

--- a/structure/templates/structure/structure_browser.html
+++ b/structure/templates/structure/structure_browser.html
@@ -226,6 +226,18 @@
             }
         });
 
+        var params = new URLSearchParams(window.location.search);
+        var method = params.get('method');
+        var state = params.get('state');
+        if (method) {
+            table.column(5).search('^' + method + '$', true, false).draw();
+            $(table.column(5).header()).find('select').val(method);
+        }
+        if (state) {
+            table.column(7).search('^' + state + '$', true, false).draw();
+            $(table.column(7).header()).find('select').val(state);
+        }
+
         // Clickable row functionality
         $('#residues tbody').on('click', 'tr', function(event) {
             // Ignore click if target is a link or a child of a link


### PR DESCRIPTION
## Summary
- reduce page load and crash risk by loading structure data once and reusing across chart generators
- show legend and slice labels in pie charts and make slices link to filtered browse pages
- allow browse tables to accept URL params for pre-filtering

## Testing
- `pytest`
- `python manage.py check`
