### PR TITLE
Add residue-based search for chemokine-partner complexes

### DIFF
--- a/interaction/templates/interaction/residue_search.html
+++ b/interaction/templates/interaction/residue_search.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Chemokine Residue Search</h1>
+<form method="get">
+  <label for="ccn_numbers">Select CCN numbers:</label>
+  <select name="ccn_numbers" multiple id="ccn_numbers" class="form-control">
+    {% for ccn in ccn_choices %}
+    <option value="{{ ccn }}"{% if ccn in selected_ccn_numbers %} selected{% endif %}>{{ ccn }}</option>
+    {% endfor %}
+  </select>
+  <button type="submit" class="btn btn-primary mt-2">Search</button>
+</form>
+
+{% if binding_partners %}
+  <h2 class="mt-4">Results</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>PDB</th>
+        <th>Chemokine Chain</th>
+        <th>Partner</th>
+        <th>Partner Chain</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for bp in binding_partners %}
+      <tr>
+        <td>{{ bp.structure.pdb_code.index }}</td>
+        <td>{{ bp.chemokine_chain }}</td>
+        <td>{{ bp.partner_name }}</td>
+        <td>{{ bp.partner_chain }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+{% endblock %}

--- a/interaction/tests.py
+++ b/interaction/tests.py
@@ -1,3 +1,96 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
 
-# Create your tests here.
+from common.models import WebResource, WebLink, ResiduePosition
+from structure.models import Structure, PdbData, Rotamer, ChemokineBindingPartner
+from interaction.models import ChemokinePartnerInteraction
+from interaction.views import ResidueSearchView
+from residue.models import Residue
+
+
+class ResidueSearchViewTests(TestCase):
+    def setUp(self):
+        ResiduePosition.objects.create(position=1, ccn_number="B1.10")
+        ResiduePosition.objects.create(position=2, ccn_number="B2.20")
+
+        wr = WebResource.objects.create(slug="pdb", name="PDB")
+        wl = WebLink.objects.create(web_resource=wr, index="1ABC")
+        self.structure = Structure.objects.create(pdb_code=wl)
+        pdbdata = PdbData.objects.create(pdb="test")
+
+        res1 = Residue.objects.create(
+            protein=None,
+            sequence_number=1,
+            ccn_number="B1.10",
+            amino_acid="A",
+            amino_acid_three_letter="ALA",
+        )
+        rot1 = Rotamer.objects.create(
+            residue=res1,
+            structure=self.structure,
+            pdbdata=pdbdata,
+            chain="A",
+            sequence_number=1,
+            ccn_number="B1.10",
+            amino_acid="A",
+            amino_acid_three_letter="ALA",
+        )
+        res2 = Residue.objects.create(
+            protein=None,
+            sequence_number=2,
+            ccn_number="B2.20",
+            amino_acid="G",
+            amino_acid_three_letter="GLY",
+        )
+        rot2 = Rotamer.objects.create(
+            residue=res2,
+            structure=self.structure,
+            pdbdata=pdbdata,
+            chain="A",
+            sequence_number=2,
+            ccn_number="B2.20",
+            amino_acid="G",
+            amino_acid_three_letter="GLY",
+        )
+
+        self.bp1 = ChemokineBindingPartner.objects.create(
+            structure=self.structure,
+            chemokine_chain="A",
+            partner_chain="B",
+            chemokine_name="CK1",
+            partner_name="P1",
+        )
+        self.bp2 = ChemokineBindingPartner.objects.create(
+            structure=self.structure,
+            chemokine_chain="A",
+            partner_chain="C",
+            chemokine_name="CK1",
+            partner_name="P2",
+        )
+        ChemokinePartnerInteraction.objects.create(
+            chemokine_residue=rot1,
+            partner_residue="X",
+            partner_name="P1",
+            partner_chain="B",
+            interaction_type="contact",
+            structure=self.structure,
+            chemokine_binding_partner=self.bp1,
+        )
+        ChemokinePartnerInteraction.objects.create(
+            chemokine_residue=rot2,
+            partner_residue="Y",
+            partner_name="P2",
+            partner_chain="C",
+            interaction_type="contact",
+            structure=self.structure,
+            chemokine_binding_partner=self.bp2,
+        )
+
+    def test_filter_by_ccn_number(self):
+        factory = RequestFactory()
+        url = reverse("interaction:residue_search")
+        request = factory.get(url, {"ccn_numbers": ["B1.10"]})
+        response = ResidueSearchView.as_view()(request)
+        context = response.context_data
+        partners = list(context.get("binding_partners"))
+        self.assertEqual(partners, [self.bp1])

--- a/interaction/urls.py
+++ b/interaction/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     path('similarity-matrix/', views.IFPSimilarityMatrixView.as_view(), name='ifp_similarity_matrix'),
     path('binding-partner/<int:binding_partner_id>/pdb_download/', views.PDBDownload.as_view(), name='pdb_download'),
     path('ifp/similarity/antibody/', views.IFPSimilarityMatrixAntibodyView.as_view(), name='ifp_similarity_antibody'),
+    path('residue-search/', views.ResidueSearchView.as_view(), name='residue_search'),
 ]

--- a/interaction/views.py
+++ b/interaction/views.py
@@ -49,6 +49,7 @@ from structure.utils import *
 from structure.models import Structure, PdbData, Rotamer, Entity, ChemokineBindingPartner
 from protein.models import Protein
 from residue.models import Residue
+from common.models import ResiduePosition
 from interaction.models import (
     ChemokinePartnerInteraction,
     ChemokinePartnerIFP,
@@ -942,14 +943,29 @@ class IFPSimilarityMatrixView(TemplateView):
         return sim_matrix
 
 
+class ResidueSearchView(TemplateView):
+    """Allow users to filter chemokine-partner complexes by CCN numbers."""
 
-from django.views.generic import TemplateView
-from interaction.models import ChemokinePartnerIFP
-import numpy as np
-import plotly.graph_objects as go
-from scipy.spatial.distance import squareform
-from scipy.cluster.hierarchy import linkage, dendrogram
-from rdkit.DataStructs.cDataStructs import TanimotoSimilarity
+    template_name = "interaction/residue_search.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["ccn_choices"] = list(
+            ResiduePosition.objects.order_by("position").values_list("ccn_number", flat=True)
+        )
+        selected = self.request.GET.getlist("ccn_numbers")
+        context["selected_ccn_numbers"] = selected
+        if selected:
+            interactions = ChemokinePartnerInteraction.objects.filter(
+                chemokine_residue__ccn_number__in=selected
+            )
+            bp_ids = interactions.values_list("chemokine_binding_partner_id", flat=True).distinct()
+            context["binding_partners"] = ChemokineBindingPartner.objects.filter(
+                id__in=bp_ids
+            ).select_related("structure")
+        return context
+
+
 
 class IFPSimilarityMatrixAntibodyView(TemplateView):
     template_name = 'interaction/ifp_similarity_matrix_antibody.html'


### PR DESCRIPTION
## Summary
- Allow filtering complexes by selecting chemokine CCN numbers
- Expose new `/interaction/residue-search/` page with form and results
- Cover search logic with unit test

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c1437108e483238d25206705c4c304